### PR TITLE
Feat: custom linarith tactic

### DIFF
--- a/Game/CustomTactic/Linarith.lean
+++ b/Game/CustomTactic/Linarith.lean
@@ -13,3 +13,5 @@ elab_rules (kind := Game.linarith) : tactic
     let args ← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `linarith)
     let cfg := (← elabLinarithConfig cfg).updateReducibility bang.isSome
     commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith true args.toList cfg
+  | `(tactic| linarith $[!%$bang]? $cfg:optConfig only%$o $[[$args,*]]?) =>
+    throwError "In this game, `linarith` has no `only` keyword!"

--- a/Game/CustomTactic/Linarith.lean
+++ b/Game/CustomTactic/Linarith.lean
@@ -5,12 +5,11 @@ open Mathlib.Tactic in
 @[inherit_doc Mathlib.Tactic.linarith]
 syntax (name := Game.linarith) "linarith" "!"? linarithArgsRest : tactic
 
--- This is copied from the Mathlib tactic `linarith` where the `only` keyword has been
--- made mandatory
+-- This is copied from the Mathlib tactic `linarith`
+-- the keyword `only` has been removed but the tactic behaves as if it was always specified
 open Lean Mathlib Syntax Elab Tactic in
 elab_rules (kind := Game.linarith) : tactic
-  | `(tactic| linarith $[!%$bang]? $cfg:optConfig only%$o [$args,*]) => withMainContext do
-    let args ← (args.getElems).mapM (elabLinarithArg `linarith)
+  | `(tactic| linarith $[!%$bang]? $cfg:optConfig $[[$args,*]]?) => withMainContext do
+    let args ← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `linarith)
     let cfg := (← elabLinarithConfig cfg).updateReducibility bang.isSome
     commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith true args.toList cfg
-  | `(tactic| linarith $[!%$bang]? $cfg:optConfig) => throwError "In this game, `linarith` requires to specify `only` explicitly: Write `linarith only []`"

--- a/Game/CustomTactic/Linarith.lean
+++ b/Game/CustomTactic/Linarith.lean
@@ -1,0 +1,16 @@
+import Mathlib.Tactic.Linarith
+
+open Mathlib.Tactic in
+
+@[inherit_doc Mathlib.Tactic.linarith]
+syntax (name := Game.linarith) "linarith" "!"? linarithArgsRest : tactic
+
+-- This is copied from the Mathlib tactic `linarith` where the `only` keyword has been
+-- made mandatory
+open Lean Mathlib Syntax Elab Tactic in
+elab_rules (kind := Game.linarith) : tactic
+  | `(tactic| linarith $[!%$bang]? $cfg:optConfig only%$o [$args,*]) => withMainContext do
+    let args ← (args.getElems).mapM (elabLinarithArg `linarith)
+    let cfg := (← elabLinarithConfig cfg).updateReducibility bang.isSome
+    commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith true args.toList cfg
+  | `(tactic| linarith $[!%$bang]? $cfg:optConfig) => throwError "In this game, `linarith` requires to specify `only` explicitly: Write `linarith only []`"

--- a/Game/Metadata.lean
+++ b/Game/Metadata.lean
@@ -1,6 +1,7 @@
 import GameServer
 
 import Game.CustomTactic.Rw  -- weaker `rw` which behaves like Lean's `rewrite` tactic (i.e. uses no `rfl`)
+import Game.CustomTactic.Linarith -- `linarith` with required `only` keyword
 
 /-! Use this file to add things that should be available in all levels.
 

--- a/Game/Metadata.lean
+++ b/Game/Metadata.lean
@@ -1,7 +1,7 @@
 import GameServer
 
 import Game.CustomTactic.Rw  -- weaker `rw` which behaves like Lean's `rewrite` tactic (i.e. uses no `rfl`)
-import Game.CustomTactic.Linarith -- `linarith` with required `only` keyword
+import Game.CustomTactic.Linarith -- modified `linarith` tactic
 
 /-! Use this file to add things that should be available in all levels.
 


### PR DESCRIPTION
Custom linarith tactic which always requires `linarith only []`