### PR TITLE
chore: cleanup and adding tests

### DIFF
--- a/.i18n/en/Game.pot
+++ b/.i18n/en/Game.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Project-Id-Version: Game v4.23.0-rc2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-05\n"
+"POT-Creation-Date: 2025-09-06\n"
 "Last-Translator: \n"
 "Language-Team: none\n"
 "Language: en\n"

--- a/Game.lean
+++ b/Game.lean
@@ -42,5 +42,7 @@ Languages "en"
 CaptionShort "A First Course in Real Analysis"
 CaptionLong "Learn real analysis through the historical crises that forced mathematicians to rebuild calculus from the ground up in the 19th century."
 
+set_option lean4game.showDependencyReasons true
+
 /-! Build the game. Show's warnings if it found a problem with your game. -/
 MakeGame

--- a/Game/Levels/L1Pset/L1Pset1.lean
+++ b/Game/Levels/L1Pset/L1Pset1.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "L1Pset"
 Level 1

--- a/Game/Levels/L1Pset/L1Pset2.lean
+++ b/Game/Levels/L1Pset/L1Pset2.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "L1Pset"
 Level 2

--- a/Game/Levels/L1Pset/L1Pset3.lean
+++ b/Game/Levels/L1Pset/L1Pset3.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "L1Pset"
 Level 3

--- a/Game/Levels/L1Pset/L1Pset4.lean
+++ b/Game/Levels/L1Pset/L1Pset4.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "L1Pset"
 Level 4

--- a/Game/Levels/L1Pset/L1Pset5.lean
+++ b/Game/Levels/L1Pset/L1Pset5.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "L1Pset"
 Level 5

--- a/Game/Levels/L1RealAnalysisStory/L00_the_problem.lean
+++ b/Game/Levels/L1RealAnalysisStory/L00_the_problem.lean
@@ -1,5 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 1

--- a/Game/Levels/L1RealAnalysisStory/L02_rfl.lean
+++ b/Game/Levels/L1RealAnalysisStory/L02_rfl.lean
@@ -1,5 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 2

--- a/Game/Levels/L1RealAnalysisStory/L03_rw.lean
+++ b/Game/Levels/L1RealAnalysisStory/L03_rw.lean
@@ -1,5 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 3

--- a/Game/Levels/L1RealAnalysisStory/L04_ring_nf.lean
+++ b/Game/Levels/L1RealAnalysisStory/L04_ring_nf.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 4

--- a/Game/Levels/L1RealAnalysisStory/L05_use.lean
+++ b/Game/Levels/L1RealAnalysisStory/L05_use.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 5

--- a/Game/Levels/L1RealAnalysisStory/L06_intro.lean
+++ b/Game/Levels/L1RealAnalysisStory/L06_intro.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 6

--- a/Game/Levels/L1RealAnalysisStory/L07_specialize.lean
+++ b/Game/Levels/L1RealAnalysisStory/L07_specialize.lean
@@ -1,5 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 7

--- a/Game/Levels/L1RealAnalysisStory/L08_obtain.lean
+++ b/Game/Levels/L1RealAnalysisStory/L08_obtain.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 8

--- a/Game/Levels/L1RealAnalysisStory/L09_big_boss.lean
+++ b/Game/Levels/L1RealAnalysisStory/L09_big_boss.lean
@@ -1,6 +1,4 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
 
 World "RealAnalysisStory"
 Level 9

--- a/Game/Levels/L2NewtonsCalculationOfPi/L01_SeqConvDef.lean
+++ b/Game/Levels/L2NewtonsCalculationOfPi/L01_SeqConvDef.lean
@@ -1,6 +1,5 @@
-import GameServer
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Ring
+import Game.Metadata
+
 
 World "NewtonsCalculationOfPi"
 Level 1
@@ -120,11 +119,10 @@ and you want to convert it to plain old `0`, try calling `norm_num`.
 Ok, get to it!
 "
 
+
 /-- The `change` tactic changes a goal to something definitionally equal to it. If the definition of `X` is `Y`, that is, `X := Y`, and the Goal is `X`, you can write `change Y` and the Goal will change to `Y`. You can also
 do this at a hypothesis; if you have a hypothesis `h : X`, you can write `change Y at h`, and `h` will change to `h : Y`. -/
 TacticDoc change
-
-NewTactic change
 
 /-- For a sequence `a : ℕ → ℝ` and a real number `L : ℝ`, we say that `SeqLim a L` holds if: for every `ε > 0`, there exists `N : ℕ` such that for all `n ≥ N`, we have `|a n - L| < ε`. -/
 DefinitionDoc SeqLim as "SeqLim"
@@ -137,8 +135,7 @@ def SeqLim (a : ℕ → ℝ) (L : ℝ) : Prop :=
 /-- The `norm_num` tactic can normalize numerical constants and functions of them. -/
 TacticDoc norm_num
 
-NewTactic norm_num
-
+NewTactic change norm_num
 
 /--
 For any sequence `a : ℕ → ℝ` and constant `L : ℝ`, and

--- a/Game/Levels/L2NewtonsCalculationOfPi/L02_DoubleSeqConv.lean
+++ b/Game/Levels/L2NewtonsCalculationOfPi/L02_DoubleSeqConv.lean
@@ -1,5 +1,5 @@
+import Game.Metadata
 import Game.Levels.L2NewtonsCalculationOfPi.L01_SeqConvDef
-import Game.CustomTactic.Linarith
 
 World "NewtonsCalculationOfPi"
 Level 2

--- a/Game/Levels/L2NewtonsCalculationOfPi/L03_SumOfSeqs.lean
+++ b/Game/Levels/L2NewtonsCalculationOfPi/L03_SumOfSeqs.lean
@@ -1,3 +1,4 @@
+import Game.Metadata
 import Game.Levels.L2NewtonsCalculationOfPi.L02_DoubleSeqConv
 
 World "NewtonsCalculationOfPi"

--- a/Game/Levels/L2Pset/L2Pset1.lean
+++ b/Game/Levels/L2Pset/L2Pset1.lean
@@ -1,6 +1,6 @@
 import Game.Levels.L2NewtonsCalculationOfPi
 import Game.CustomTactic.Linarith
-import Mathlib.Tactics.FieldSimp
+import Mathlib.Tactic.FieldSimp
 
 World "L2Pset"
 Level 1

--- a/Game/Metadata.lean
+++ b/Game/Metadata.lean
@@ -3,6 +3,10 @@ import GameServer
 import Game.CustomTactic.Rw  -- weaker `rw` which behaves like Lean's `rewrite` tactic (i.e. uses no `rfl`)
 import Game.CustomTactic.Linarith -- modified `linarith` tactic
 
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.FieldSimp
+
 /-! Use this file to add things that should be available in all levels.
 
 For example, this demo imports the mathlib tactics

--- a/Test/FieldSimp.lean
+++ b/Test/FieldSimp.lean
@@ -1,0 +1,7 @@
+import Game.Metadata
+
+example (c : ℝ) (hc : c ≠ 0) (cpos : 0 < |c|) (cinvpos : 0 < |c|⁻¹)
+    (a : ℝ) (ε : ℝ) (hε : 0 < ε) (h : |a| < ε * |c|⁻¹) : |c| * |a| < ε := by
+  field_simp at h
+  rw [mul_comm]
+  assumption

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -60,3 +60,7 @@ package Game where
 
 @[default_target]
 lean_lib Game
+
+@[test_driver]
+lean_lib Test where
+  globs := #[.submodules `Test]


### PR DESCRIPTION
- You should import everything from Mathlib inside `Game.Metadata` to avoid side effects where some tactics aren't available in other worlds just because the imports are missing.
- Added tests which can be executed with `lake test`