### PR TITLE
Change page 08 in level 1 to say 'choose'

### DIFF
--- a/Game/Levels/L1RealAnalysisStory.lean
+++ b/Game/Levels/L1RealAnalysisStory.lean
@@ -5,7 +5,7 @@ import Game.Levels.L1RealAnalysisStory.L04_ring_nf
 import Game.Levels.L1RealAnalysisStory.L05_use
 import Game.Levels.L1RealAnalysisStory.L06_intro
 import Game.Levels.L1RealAnalysisStory.L07_specialize
-import Game.Levels.L1RealAnalysisStory.L08_obtain
+import Game.Levels.L1RealAnalysisStory.L08_choose
 import Game.Levels.L1RealAnalysisStory.L09_big_boss
 
 World "RealAnalysisStory"

--- a/Game/Levels/L1RealAnalysisStory/L08_choose.lean
+++ b/Game/Levels/L1RealAnalysisStory/L08_choose.lean
@@ -2,7 +2,7 @@ import Game.Metadata
 
 World "RealAnalysisStory"
 Level 8
-Title "The obtain tactic"
+Title "The choose tactic"
 
 Introduction "
 # Extracting information from existential quantifiers
@@ -55,7 +55,8 @@ The symmetry is beautiful:
 - `use` when you have `∃` in the goal (\"here's my specific example\")
 - `choose` when you have `∃` in a hypothesis (\"let me unpack this existence claim\")
 
-This completes your basic logical toolkit! In real analysis, you'll use `obtain` constantly when working with:
+This completes your basic logical toolkit! In real analysis, you'll use `choose` (or a similar
+tactic called `obtain`) constantly when working with:
 - Limit definitions (\"given ε > 0, there exists δ > 0...\")
 - Intermediate Value Theorem (\"there exists c such that f(c) = 0\")
 - Existence theorems throughout analysis


### PR DESCRIPTION
Small cosmetic change.  I think maybe you were going to teach the 'obtain' tactic and then changed at the last minute to using 'choose' instead.  So the page where 'choose' is introduced is called 'obtain' and mentions how you will use 'obtain' all over the place.  But 'obtain' isn't a tactic that is available at this point.

Change the wording to (I hope) preserve the intent but make it less confusing.  Also change the page name to choose so that's consistent.