### PR TITLE
Change for the Theorem LimZeroTimesBdd

### DIFF
--- a/Game/Levels/L10Pset/L10Pset2.lean
+++ b/Game/Levels/L10Pset/L10Pset2.lean
@@ -13,7 +13,7 @@ Prove the Theorem `LimZeroTimesBdd`: if a sequence `a n` converges to `0`, and t
 "
 
 /--
-If sequence `a : ℕ → ℝ` converges to `0` and sequence `b : ℕ → ℝ` is bounded by `M`, then `a n * b n` converges to `0`.
+If sequence `a : ℕ → ℝ` converges to `0` and sequence `b : ℕ → ℝ` is bounded, then `a n * b n` converges to `0`.
 -/
 TheoremDoc LimZeroTimesBdd as "LimZeroTimesBdd" in "Theorems"
 


### PR DESCRIPTION
Dear Professor Kontorovich,

The previous description for LimZeroTimesBdd was "If sequences `a b : ℕ → ℝ` converge with `a` going to `L` and `b` going to `M`, then `a n * b n` converges to `L * M`"

I changed it to be more precise and state that "If sequence `a : ℕ → ℝ` converges to `0` and sequence `b : ℕ → ℝ` is bounded, then `a n * b n` converges to `0`" since the previous definition didn't say b was bounded, and it said a converges to 'L', but that L is 0. This leads to `a n * b n` converging to `0` instead of just `L * M` to be more precise.

Thank you!

Brandon Huang