### PR TITLE
Refactor SqueezeThm statement to include N parameter

### DIFF
--- a/Game/Levels/L6Levels/L06_Squeeze.lean
+++ b/Game/Levels/L6Levels/L06_Squeeze.lean
@@ -27,8 +27,8 @@ TheoremDoc SqueezeThm as "SqueezeThm" in "Theorems"
 
 /-- Prove this
 -/
-Statement SqueezeThm (a b c : ℕ → ℝ) (L : ℝ) (aToL : SeqLim a L)
-(cToL : SeqLim c L) (aLeb : ∀ n, a n ≤ b n) (bLec : ∀ n, b n ≤ c n) :
+Statement SqueezeThm (a b c N : ℕ → ℝ) (L : ℝ) (aToL : SeqLim a L)
+(cToL : SeqLim c L) (aLeb : ∀ n ≥ N, a n ≤ b n) (bLec : ∀ n ≥ N, b n ≤ c n) :
   SeqLim b L := by
 intro ε hε
 specialize aToL ε hε


### PR DESCRIPTION
Hello Professor Kontorovich, I believe Squeeze Theorem should be slightly altered. I believe it should be:
Let (an), (cn) be two sequences converging to ℓ, and (bn) a sequence. If ∀ n ≥ N, N ∈ N we have an ≤ bn ≤ cn, then (bn) also converges to ℓ.

Currently we don't have the constraint N, and it's just an ≤ bn ≤ cn for all n, which isn't what Squeeze Theorem is.
I actually had issue with this in latest homework, because I cannot use the sequence 1/n as part of my squeeze theorem, as when n= 0 it's invalid and the an ≤ bn ≤ cn doesn't work. Fixing the definition would allow it to work that way.
Thank you for considering this suggestion!