### PR TITLE
Added additional bullet in "New Tools" section to note use of bound/r…

### DIFF
--- a/Game/Levels/L4Levels/L01_NonConverge.lean
+++ b/Game/Levels/L4Levels/L01_NonConverge.lean
@@ -113,6 +113,8 @@ And that get us the desired contradiction.
 Warning! Make sure the pattern `|-Something|` is on the left hand side. If Lean doesn't see an absolute value
 followed by a minus sign, `abs_neg` won't work!
 
+- **Equality tactics**: The `bound` and 'ring_nf' tactic also help prove some equalities as well. You can use them to prove whatever arithmetic facts seem obvious, like exponent simplifications. If one doesn't work, try the other!
+
 
 "
 


### PR DESCRIPTION
I was watching someone go through the game [here](https://www.youtube.com/watch?v=ZSyJaWJ3zcw) and it didn't seem intuitive to use `bound` for equations as well as inequalities, like in L04 where it's used to simplify (-1)^(2*N) = 1, so just added some documentation to make that clear.